### PR TITLE
Fix Makefile shell compatibility

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,9 @@
 include settings.mk
 
+# Use bash for all recipe commands. The Makefile relies on bash features such
+# as the `|&` pipe operator which are not available in POSIX `sh`.
+SHELL := /usr/bin/env bash
+
 LIB_UNISIMS_VER  = -L unisims_ver                            # Simulation fonctionnelle
 LIB_SIMPRIMS_VER = -L simprims_ver=sim_libs/simprims_ver     # Simulation temporelle
 GLBL = $(VIVADO_PATH)/data/verilog/src/glbl.v


### PR DESCRIPTION
## Summary
- ensure the Makefile runs under bash

This fixes the build error when `/bin/sh` is dash and does not support the `|&` operator.

## Testing
- `make src` *(fails: `xvlog` not found)*

------
https://chatgpt.com/codex/tasks/task_b_6866535218408324a13516c0fec4d1b0