### PR TITLE
Fix quick start documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ It wraps the usual Vivado Tcl flow in a **portable Makefile** so that every deve
 git clone <repo‑url> my_fpga_proj
 cd my_fpga_proj
 
-# 2. Adapt project variables (device, RTL list, top level) in Makefile
+# 2. Adapt project variables (device, RTL list, top level) in settings.mk
 $EDITOR settings.mk
 
 # 3. Build everything from RTL to bitstream


### PR DESCRIPTION
## Summary
- reference `settings.mk` instead of Makefile in quick-start instructions

## Testing
- `make -n`

------
https://chatgpt.com/codex/tasks/task_b_6866547baf688324b4d00f8f60c23367