### PR TITLE
Fix impl timesim SDF path

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -91,7 +91,7 @@ all: src
 	@$(XVLOG) $(LIB_SIMPRIMS_VER) -sv output/netlists/impl_timesim_netlist.v |& ${HL}
 	@$(XELAB) -s snapshot_impl_timesim \
 		-debug typical \
-		-sdfmax /tb_principal/DUT=output/netlists/synth_timesim_netlist.sdf \
+		-sdfmax /tb_principal/DUT=output/netlists/impl_timesim_netlist.sdf \
 		$(LIB_SIMPRIMS_VER) \
 		$(TB_TOP) glbl |& ${HL} 	
 	@VCD_FILE=output/waveforms/impl_timesim.vcd $(XSIM) \


### PR DESCRIPTION
## Summary
- fix `-sdfmax` path for `snapshot_impl_timesim`

## Testing
- `make -n impl_timesim`

------
https://chatgpt.com/codex/tasks/task_b_6866579e7c4c832482a354969d866831