### PR TITLE
Fix TB_SRC path formatting

### DIFF
--- a/settings.mk
+++ b/settings.mk
@@ -14,6 +14,6 @@ SRC_VHDL =
 SRC_VLG = 
 
 TB_SRC = \
-	./tb/tb_principal.sv \
+        ./tb/tb_principal.sv
 
 VIVADO_PATH = /usr/local/Xilinx/Vivado/2024.2


### PR DESCRIPTION
## Summary
- stop line continuation for the final testbench file

## Testing
- `make -f /tmp/Makefile.test print`

------
https://chatgpt.com/codex/tasks/task_b_6866579c38048324b5188e5131dd02c5