### PR TITLE
Fix ip_create_config command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -159,7 +159,7 @@ ip_create_config:
 		echo "Creating IP config for $(IP_NAME) ..." ; \
 		mkdir -p ./ip/config_templates ; \
 		$(VIVADO) -source ./scripts/ip_create_config.tcl \
-			-tclargs ${PART} ${IP_NAME} ; |& $(HL)\
+			-tclargs ${PART} ${IP_NAME} |& $(HL)
 	fi
 
 


### PR DESCRIPTION
## Summary
- remove stray semicolon and backslash in ip_create_config recipe

## Testing
- `make -n ip_create_config IP_NAME=dummy`

------
https://chatgpt.com/codex/tasks/task_b_6866579b5b9c8324b22025e2759d267f