### PR TITLE
Fix extraneous semicolon

### DIFF
--- a/tb/tb_principal.sv
+++ b/tb/tb_principal.sv
@@ -27,7 +27,7 @@ initial begin
     nrst = 0 ;
     #20 ;
     nrst = 1 ;
- end ;     
+end
 
     
 endmodule


### PR DESCRIPTION
## Summary
- remove stray semicolon from tb_principal.sv

## Testing
- `make tb` *(fails: `xvlog: command not found`)*

------
https://chatgpt.com/codex/tasks/task_b_68665b5d23f483249fd7edfb834f36d6