### PR TITLE
Improve source type handling in synthesis TCL

### DIFF
--- a/scripts/synthesis.tcl
+++ b/scripts/synthesis.tcl
@@ -3,7 +3,18 @@ set top  [lindex $argv 1]
 set xdc  [lindex $argv 2]
 set src  [lrange $argv 3 end]
 foreach f $src {
-    read_verilog $f 		;# FIXME C'est pas forcement du verilog !
+    set ext [string tolower [file extension $f]]
+    switch -- $ext {
+        ".vhd" - ".vhdl" {
+            read_vhdl $f
+        }
+        ".sv" {
+            read_verilog -sv $f
+        }
+        default {
+            read_verilog $f
+        }
+    }
 }
 read_xdc ${xdc}
 synth_design -top ${top} -part ${part}
@@ -12,4 +23,4 @@ write_sdf -process_corner slow -force output/netlists/synth_timesim_netlist.sdf
 write_verilog -mode design -force output/netlists/synth_design_netlist.v
 write_verilog -mode funcsim -force output/netlists/synth_funcsim_netlist.v
 write_checkpoint -force checkpoints/synth.dcp
-exit 
+exit


### PR DESCRIPTION
## Summary
- make synthesis.tcl detect each file extension
- use `read_vhdl` for VHDL files and `read_verilog -sv` for SystemVerilog

## Testing
- `make -n synth`
- `tclsh scripts/synthesis.tcl dummy dummy dummy` *(fails: invalid command name "read_xdc")*

------
https://chatgpt.com/codex/tasks/task_b_68665b5aafa48324b56b4cbf0ec800f1